### PR TITLE
Fix #1 - Can't npm start on example. Fails in webpack build

### DIFF
--- a/example/app/actions.js
+++ b/example/app/actions.js
@@ -1,8 +1,0 @@
-export function pongActionCreator (event, arg1, arg2, arg3) {
-    return {
-        type: 'IPC_PONG',
-        arg1,
-        arg2,
-        arg3
-    };
-}

--- a/example/app/app.js
+++ b/example/app/app.js
@@ -1,11 +1,29 @@
 import { applyMiddleware, createStore } from 'redux';
-import createIpc from '../../';
-import { pingActionCreator, pongActionCreator } from './actions';
-import { exampleReducer } from './reducer';
+import createIpc, { send } from '../../';
+
+function exampleReducer (state = {}, action) {
+    switch (action.type) {
+        case 'IPC_PONG':
+            console.log('Pong', action); // eslint-disable-line no-console
+            return state;
+        default:
+            return state;
+    }
+}
+
+
+function pongActionCreator (event, arg1, arg2, arg3) {
+    return {
+        type: 'IPC_PONG',
+        arg1,
+        arg2,
+        arg3
+    };
+}
 
 const ipc = createIpc({
     'pong': pongActionCreator // eslint-disable-line quote-props
 });
 const store = createStore(exampleReducer, applyMiddleware(ipc));
 
-store.dispatch(pingActionCreator('redux', 'electron', 'ipc'));
+store.dispatch(send('ping', 'redux', 'electron', 'ipc'));

--- a/example/app/reducer.js
+++ b/example/app/reducer.js
@@ -1,9 +1,0 @@
-export function exampleReducer (state = {}, action) {
-    switch (action.type) {
-        case 'IPC_PONG':
-            console.log('Pong', action); // eslint-disable-line no-console
-            return state;
-        default:
-            return state;
-    }
-}

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,8 @@
   "main": "main.js",
   "version": "1.0.0",
   "scripts": {
-    "start": "./node_modules/.bin/webpack ./app/app.js && ./node_modules/.bin/electron ."
+    "start": "./node_modules/.bin/webpack ./app/app.js && ./node_modules/.bin/electron .",
+    "postinstall": "cd .. && npm install && ./node_modules/.bin/webpack"
   },
   "devDependencies": {
     "babel-core": "^6.9.1",

--- a/example/package.json
+++ b/example/package.json
@@ -3,12 +3,13 @@
   "main": "main.js",
   "version": "1.0.0",
   "scripts": {
-    "start": "./node_modules/.bin/webpack ./app/app.js && electron ."
+    "start": "./node_modules/.bin/webpack ./app/app.js && ./node_modules/.bin/electron ."
   },
   "devDependencies": {
     "babel-core": "^6.9.1",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
+    "electron-prebuilt": "^1.4.1",
     "html-webpack-plugin": "^2.19.0",
     "redux": "^3.5.2",
     "webpack": "^1.13.1"


### PR DESCRIPTION
This fixes #1 - Can't npm start on example. Fails in webpack build.

After the `send` functionality was introduced in 1.1.0, I forgot to update the example project. This PR fixes removed imports during said update and simplifies the project structure a bit. This PR does not affect any existing module code.
